### PR TITLE
fix: the lwip_hosted_rx_input function receives raw ... in lwip_hosted.c

### DIFF
--- a/drivers/lwip_hosted/lwip_hosted.c
+++ b/drivers/lwip_hosted/lwip_hosted.c
@@ -94,7 +94,8 @@ static void lwip_hosted_rx_input(const esp_hosted_frame_info_t *info,
 
     (void)ctx;
 
-    if (!s_lwip.initialized || info == NULL || payload == NULL || len == 0U)
+    if (!s_lwip.initialized || info == NULL || payload == NULL || len == 0U ||
+        len > UINT16_MAX) /* pbuf_alloc takes u16_t; prevent silent truncation */
     {
         return;
     }


### PR DESCRIPTION
## Summary
Fix critical severity security issue in `drivers/lwip_hosted/lwip_hosted.c`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-006 |
| **Severity** | CRITICAL |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-006` |
| **File** | `drivers/lwip_hosted/lwip_hosted.c:87` |

**Description**: The lwip_hosted_rx_input function receives raw network frames from the esp_hosted wireless interface and passes them to the lwIP network stack without validating the frame length against the allocated packet buffer (pbuf) size. If an attacker sends a crafted network packet with a frame length field in esp_hosted_frame_info_t that exceeds the allocated pbuf size, the frame data copy overflows the buffer, corrupting adjacent heap memory. This vulnerability is remotely exploitable by any attacker on the same wireless network segment.

## Changes
- `drivers/lwip_hosted/lwip_hosted.c`

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
